### PR TITLE
Feat backend ids

### DIFF
--- a/backend/consumer.py
+++ b/backend/consumer.py
@@ -10,8 +10,10 @@ class Consumer(ThreadingActor):
         super(Consumer, self).__init__()
         self.producers = producers
         self.job = job
+        self.id = job.id
         self.logger = logging.getLogger("src.Consumer")
         self.clock = clock
+        self.logger.info("New consumer made with id: " + str(self.id))
 
     # Send a message to another actor in a framework agnostic way
     def send(self, message, receiver):

--- a/backend/job.py
+++ b/backend/job.py
@@ -12,7 +12,8 @@ class JobStatus(Enum):
 
 class Job:
 
-    def __init__(self, est, lst, load_profile):
+    def __init__(self, id, est, lst, load_profile):
+        self.id = id
         self.est = est
         self.lst = lst
         self.load_profile = load_profile

--- a/backend/producer.py
+++ b/backend/producer.py
@@ -13,13 +13,15 @@ import time
 
 
 class Producer(ThreadingActor):
-    def __init__(self, manager):
+    def __init__(self, id, manager):
         super(Producer, self).__init__()
+        self.id = id
         self.optimizer = Optimizer(self)
         self.schedule = []
         self.prediction = pd.Series()
         self.logger = logging.getLogger("src.Producer")
         self.manager = manager
+        self.logger.info("New producer with made with id: " + str(self.id))
 
     # Send a message to another actor in a framework agnostic way
     def send(self, message, receiver):
@@ -32,7 +34,7 @@ class Producer(ThreadingActor):
     def receive(self, message, sender):
         action = message['action']
 
-        if action == Action.broadcast:
+        if action == Action.prediction:
             self.update_power_profile(message["prediction"])
             self.optimize()
 

--- a/tests/mock_clock.py
+++ b/tests/mock_clock.py
@@ -1,0 +1,3 @@
+class MockClock:
+    def __init__(self):
+        self.now = 0

--- a/tests/test_consumer_pytest.py
+++ b/tests/test_consumer_pytest.py
@@ -5,12 +5,12 @@ from backend.consumer import Consumer
 from backend.job import Job, JobStatus
 from backend.producer import Producer
 import pandas as pd
-
+from .mock_clock import MockClock
 
 def test_request_producer():
-    producer = Producer.start(None)
-    job = Job(est=-1, lst=1, load_profile=pd.Series(index=[0.0, 3600.0], data=[0.0, 1.0]))
-    consumer = Consumer.start([producer], job)
+    producer = Producer.start("id", None)
+    job = Job("id", est=-1, lst=1, load_profile=pd.Series(index=[0.0, 3600.0], data=[0.0, 1.0]))
+    consumer = Consumer.start([producer], job, MockClock())
 
     consumer._actor.request_producer()
 

--- a/tests/test_input_utils_pytest.py
+++ b/tests/test_input_utils_pytest.py
@@ -22,7 +22,7 @@ def test_load_profile_from_csv():
 
 def test_job_from_consumer_event():
     csv1 = "1460246602;1460246602;1460246622;[57]:[222]:[3];57_back_3.csv"
-    expected1 = Job(1460246602, 1460246622, pd.Series(index=[0.0, 3600.0], data=[0.0, 0.286903377284]))
+    expected1 = Job("id", 1460246602, 1460246622, pd.Series(index=[0.0, 3600.0], data=[0.0, 0.286903377284]))
     actual1 = utils.job_from_consumer_event(csv1, "test")
 
     assert expected1 == actual1

--- a/tests/test_job_pytest.py
+++ b/tests/test_job_pytest.py
@@ -9,7 +9,7 @@ import pytest
 
 def test_to_message():
     load_profile = pd.Series(index=[0.0, 3600.0], data=[0.0, 1.0])
-    job = Job(0, 1, load_profile)
+    job = Job("id", 0, 1, load_profile)
 
     expected = dict(est=0, lst=1, load_profile=load_profile)
     actual = job.to_message()

--- a/tests/test_manager_pytest.py
+++ b/tests/test_manager_pytest.py
@@ -3,11 +3,11 @@ import os
 sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/..")
 from backend.manager import Manager
 from backend.producer import Producer
-
+from .mock_clock import MockClock
 
 def test_register_producer():
     # Make a manager with no neighbourhood (not needed for testing)
     manager = Manager()
-    producer = Producer(manager)
-    manager.register_producer(producer)
+    producer = Producer(manager, MockClock())
+    manager.register_producer("id", producer)
     assert producer in manager.producers

--- a/tests/test_optimizer_pytest.py
+++ b/tests/test_optimizer_pytest.py
@@ -11,13 +11,13 @@ from backend.producer import Producer
 
 def test_optimize():
     man = Manager()
-    producer = Producer(man)
-    job0 = (None, Job(0, 0, pd.Series(index=[0, 3], data=[40, 40])), JobStatus.active)
-    job1 = (None, Job(0, 0, pd.Series(index=[2, 4], data=[30, 30])), JobStatus.active)
-    job2 = (None, Job(0, 0, pd.Series(index=[5, 6], data=[10, 10])), JobStatus.active)
-    job3 = (None, Job(0, 0, pd.Series(index=[5, 6], data=[40, 40])), JobStatus.active)
-    job4 = (None, Job(0, 0, pd.Series(index=[7, 10], data=[50, 50])), JobStatus.active)
-    job5 = (None, Job(0, 0, pd.Series(index=[7, 10], data=[40, 40])), JobStatus.active)
+    producer = Producer("id", man)
+    job0 = (None, Job("id", 0, 0, pd.Series(index=[0, 3], data=[40, 40])), JobStatus.active)
+    job1 = (None, Job("id", 0, 0, pd.Series(index=[2, 4], data=[30, 30])), JobStatus.active)
+    job2 = (None, Job("id", 0, 0, pd.Series(index=[5, 6], data=[10, 10])), JobStatus.active)
+    job3 = (None, Job("id", 0, 0, pd.Series(index=[5, 6], data=[40, 40])), JobStatus.active)
+    job4 = (None, Job("id", 0, 0, pd.Series(index=[7, 10], data=[50, 50])), JobStatus.active)
+    job5 = (None, Job("id", 0, 0, pd.Series(index=[7, 10], data=[40, 40])), JobStatus.active)
     producer.schedule = [job0, job1, job2, job3, job4, job5]
     producer.prediction = pd.Series(index=[0, 10], data=[50, 50])
 

--- a/util/input_utils.py
+++ b/util/input_utils.py
@@ -9,11 +9,12 @@ def job_from_consumer_event(csv_line, config_name):
     split = csv_line.split(";")
     est = int(split[1])
     lst = int(split[2])
+    id = str(split[3])
     load_profile_name = split[4]
     load_profile_path = os.path.join(ROOT_DIR, "input", config_name, "loads", load_profile_name)
     load_profile_csv = open(load_profile_path, "r").read()
     load_profile = load_profile_from_csv(load_profile_csv)
-    return Job(est, lst, load_profile)
+    return Job(id, est, lst, load_profile)
 
 
 def load_profile_from_csv(csv):
@@ -51,9 +52,7 @@ def prediction_profile_from_csv(prediction_csv):
     return pd.Series(data=values, index=timestamps)
 
 
-def prediction_from_producer_event(csv_line, config_name):
-    split = csv_line.split(";")
-    prediction_file = split[2]
+def prediction_from_producer_event(prediction_file, config_name):
     prediction_profile_path = os.path.join(ROOT_DIR, "input", config_name, "predictions", prediction_file)
     prediction_csv = open(prediction_profile_path, "r").read()
     prediction_profile = prediction_profile_from_csv(prediction_csv)
@@ -67,10 +66,13 @@ def get_predictions_from_csv(config_name):
     predictions_lines = predictions_csv.split("\n")
     for line in predictions_lines:
         if line is not "":
-            timestamp = line.split(";")[0]
+            line = line.split(";")
+            id = line[1]
+            timestamp = line[0]
             predictions.append({
+                "id": id,
                 "timestamp": timestamp,
-                "prediction": prediction_from_producer_event(line, config_name)
+                "prediction": prediction_from_producer_event(line[2], config_name)
             })
     return predictions
 


### PR DESCRIPTION
+ Every backend component now has a id loaded from the CSV

+ New prediction logic in manager, only producers with the correct prediction id now gets the prediction (from broadcasting to single message).

+ New logic in manager to handle id checking for producers.

+ New termination logic of producers in both manager and simulator