### PR TITLE
Fix contract loading

### DIFF
--- a/apps/simulate_esn.py
+++ b/apps/simulate_esn.py
@@ -314,7 +314,7 @@ def update_pie_chart(run_choice, simulation_choice):
             go.Pie(
                 values=[grid, pv],
                 labels=["Grid", "PV"],
-                marker=dict(colors=['#008000', '#FF0000'])
+                marker=dict(colors=['#FF0000', '#008000'])
             )
         ]
     )

--- a/apps/simulate_esn.py
+++ b/apps/simulate_esn.py
@@ -207,11 +207,6 @@ layout = html.Div(children=[
 ])
 
 
-def print_contracts(contracts):
-    print("Length: " + str(len(contracts)))
-    for contract in contracts:
-        print(contract["id"])
-
 
 """-------------------------DROPDOWNS-------------------------"""
 
@@ -251,10 +246,9 @@ def update_houseid_dropdown(run_choice, simulation_choice):
     house_options = []
     house_id = []
     for contract in contracts:
-        contract_e = contract
-        before = contract_e['job_id'].index('[') + 1
-        after = contract_e['job_id'].index(']')
-        household_id = contract_e['job_id'][before:after]
+        before = contract['job_id'].index('[') + 1
+        after = contract['job_id'].index(']')
+        household_id = contract['job_id'][before:after]
         if household_id not in house_id:
             house_id.append(household_id)
             house_options.append({'label': 'Consumer ID: {}'.format(household_id), 'value': '{}'.format(household_id)})
@@ -273,9 +267,7 @@ def update_contracts(run_choice, simulation_choice):
     contracts = contracts[int(run_choice) - 1]
     rows = []
     for contract in contracts:
-        # print('Load profile before filtering: {}'.format(contract_e["load_profile"]))
         contract["load_profile"] = round(contract["load_profile"].values[-1], 2)
-        # print('Load profile after: {}'.format(contract_e["load_profile"]))
         contract = dataprocess.rename_columns(contract)
         rows.append(contract)
     return rows
@@ -291,10 +283,7 @@ def update_contracts(household_choice, run_choice, simulation_choice):
     contracts = contracts[int(run_choice) - 1]
     rows = []
     for contract in contracts:
-        contract_e = contract
-        # print('Load profile before filtering: {}'.format(contract_e["load_profile"]))
         contract["load_profile"] = round(contract.get("load_profile").values[-1], 2)
-        # print('Load profile after filtering: {}'.format(contract_e["load_profile"]))
         contract = dataprocess.rename_columns(contract)
         if contract.get("Consumer ID").startswith('[{}]'.format(household_choice)):
             rows.append(contract)

--- a/data_processing.py
+++ b/data_processing.py
@@ -1,10 +1,12 @@
 import pandas as pd
 import numpy as np
 import pickle
-
+import os.path
+from definitions import ROOT_DIR
 
 def open_file(file_name):
-    with open('./results/{}'.format(file_name), 'rb') as f:
+    path = os.path.join(ROOT_DIR, "results", file_name)
+    with open(path, 'rb') as f:
         res = pickle.load(f)
         contracts = res[0]
         profiles = res[1]

--- a/data_processing.py
+++ b/data_processing.py
@@ -6,12 +6,23 @@ from definitions import ROOT_DIR
 
 def open_file(file_name):
     path = os.path.join(ROOT_DIR, "results", file_name)
+    print("opening " + path)
     with open(path, 'rb') as f:
         res = pickle.load(f)
         contracts = res[0]
         profiles = res[1]
     return contracts, profiles
 
+def get_contracts(file_name):
+    contracts, profiles = open_file(file_name)
+    print("CONTRACTS")
+    print(len(contracts))
+    print(len(contracts[0]))
+    return contracts
+
+def get_profiles(file_name):
+    contracts, profiles = open_file(file_name)
+    return profiles
 
 def rename_columns(contract):
     old_keys = ["id", "time", "time_of_agreement", "load_profile", "job_id", "producer_id"]


### PR DESCRIPTION
Fixes #122 and #125.

#122 is fixed by rewriting every function that loads and uses contracts. They now first choose the inner list by run-number at the start, and iterates through the contracts after.

#125 is fixed by defaulting the run-number to None, and only displaying the data when choosing a run number. This forces the user to interact with the run-number, and all the data-loading functions listens to the run-number.